### PR TITLE
5.5.0 hotfix

### DIFF
--- a/ATI.Services.Consul/ConsulServiceAddressCache.cs
+++ b/ATI.Services.Consul/ConsulServiceAddressCache.cs
@@ -51,8 +51,10 @@ namespace ATI.Services.Consul
             if (!_useCaching)
                 return;
             
-            if (_reloadCacheTask is {IsCompleted:true} or {IsCompletedSuccessfully:true})
-                _reloadCacheTask = GetServiceFromConsulAsync();
+            if (!_reloadCacheTask.IsCompleted)
+                return;
+            
+            _reloadCacheTask = GetServiceFromConsulAsync();
         }
 
         /// <summary>
@@ -61,9 +63,6 @@ namespace ATI.Services.Consul
         private async Task CheckCacheWasInitializedAsync()
         {
             if (!_useCaching)
-                return;
-
-            if (_reloadCacheTask.IsCompleted || _reloadCacheTask.IsCompletedSuccessfully)
                 return;
 
             _cachedServices = await _reloadCacheTask;

--- a/ATI.Services.Consul/ConsulServiceAddressCache.cs
+++ b/ATI.Services.Consul/ConsulServiceAddressCache.cs
@@ -35,12 +35,9 @@ namespace ATI.Services.Consul
         /// Возвращает коллекцию сервисов 
         /// </summary>
         /// <returns></returns>
-        public async Task<List<ServiceEntry>> GetCachedObjectsAsync()
+        public Task<List<ServiceEntry>> GetCachedObjectsAsync()
         {
-            if(!_useCaching)
-                return await GetServiceFromConsulAsync();
-            
-            return await _reloadCacheTask;
+            return _useCaching ? _reloadCacheTask : GetServiceFromConsulAsync();
         }
 
         /// <summary>

--- a/ATI.Services.Consul/ConsulServiceAddressCache.cs
+++ b/ATI.Services.Consul/ConsulServiceAddressCache.cs
@@ -14,7 +14,6 @@ namespace ATI.Services.Consul
     public class ConsulServiceAddressCache
     {
         private Task<List<ServiceEntry>> _reloadCacheTask;
-        private List<ServiceEntry> _cachedServices;
         private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
         private readonly bool _useCaching;
         private readonly string _serviceName;
@@ -28,8 +27,7 @@ namespace ATI.Services.Consul
             
             if (!_useCaching)
                 return;
-
-            _cachedServices = new();
+            
             _reloadCacheTask = GetServiceFromConsulAsync();
         }
         
@@ -39,8 +37,10 @@ namespace ATI.Services.Consul
         /// <returns></returns>
         public async Task<List<ServiceEntry>> GetCachedObjectsAsync()
         {
-            await CheckCacheWasInitializedAsync();
-            return _cachedServices ?? await GetServiceFromConsulAsync();
+            if(!_useCaching)
+                return await GetServiceFromConsulAsync();
+            
+            return await _reloadCacheTask;
         }
 
         /// <summary>
@@ -55,17 +55,6 @@ namespace ATI.Services.Consul
                 return;
             
             _reloadCacheTask = GetServiceFromConsulAsync();
-        }
-
-        /// <summary>
-        /// Проверяем завершилось ли сохранение доступных сервисов в кеш
-        /// </summary>
-        private async Task CheckCacheWasInitializedAsync()
-        {
-            if (!_useCaching)
-                return;
-
-            _cachedServices = await _reloadCacheTask;
         }
 
         /// <summary>


### PR DESCRIPTION
5.5.0 hotfix:
(Иногда, при неоднократном вызове ReloadCache() метода из таймера, кеш попадает в состояния, когда таска обновления успела завершиться успешно, но при этом результата ещё никто не ожидал.)
1. CheckCacheWasInitializedAsync теперь обязательно ожидает результат из таски (в случае повтороного ожидания завершенной таски результат вернется немедленно)
2. Упростил условие в ReloadCache(), кеш не будет перезагружаться если есть не завершенная таска перезегрузки кеша.