### PR TITLE
Possibility to log timeouts as Warnings

### DIFF
--- a/ATI.Services.Consul/ATI.Services.Consul.csproj
+++ b/ATI.Services.Consul/ATI.Services.Consul.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="atisu.services.common" Version="11.0.0" />
+    <PackageReference Include="atisu.services.common" Version="11.2.0-timeout-as-warn-v2" />
     <PackageReference Include="Consul" Version="0.7.2.6" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.Consul/ATI.Services.Consul.csproj
+++ b/ATI.Services.Consul/ATI.Services.Consul.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="atisu.services.common" Version="11.2.0-timeout-as-warn-v2" />
+    <PackageReference Include="atisu.services.common" Version="11.2.0-timeout-as-warn-v3" />
     <PackageReference Include="Consul" Version="0.7.2.6" />
   </ItemGroup>
 </Project>

--- a/ATI.Services.Consul/ConsulMetricsHttpClientWrapper.cs
+++ b/ATI.Services.Consul/ConsulMetricsHttpClientWrapper.cs
@@ -20,6 +20,7 @@ namespace ATI.Services.Consul
     [PublicAPI]
     public class ConsulMetricsHttpClientWrapper
     {
+        private readonly BaseServiceOptions _serviceOptions;
         private readonly TracingHttpClientWrapper _clientWrapper;
         private readonly MetricsTracingFactory _metricsTracingFactory;
         private readonly ConsulServiceAddress _serviceAddress;
@@ -31,8 +32,9 @@ namespace ATI.Services.Consul
             JsonSerializerSettings newtonsoftSettings = null,
             JsonSerializerOptions systemTextJsonOptions = null)
         {
+            _serviceOptions = serviceOptions;
             _metricsTracingFactory = MetricsTracingFactory.CreateHttpClientMetricsFactory(adapterName,
-                serviceOptions.ConsulName, serviceOptions.LongRequestTime);
+                                                                                          serviceOptions.ConsulName, serviceOptions.LongRequestTime);
 
             _serviceAddress =
                 new ConsulServiceAddress(serviceOptions.ConsulName, serviceOptions.Environment);
@@ -40,7 +42,7 @@ namespace ATI.Services.Consul
             var config = new TracedHttpClientConfig(serviceOptions.ConsulName, serviceOptions.TimeOut, 
                 serviceOptions.SerializerType, serviceOptions.AddCultureToRequest, newtonsoftSettings, systemTextJsonOptions)
             {
-                LogTimeoutsAsWarn = serviceOptions.LogTimeoutsAsWarn,
+                LogLevelOverride = serviceOptions.LogLevelOverride,
                 HeadersToProxy = serviceOptions.HeadersToProxy
             };
 
@@ -260,7 +262,9 @@ namespace ATI.Services.Consul
                 }
                 catch (Exception e)
                 {
-                    _logger.ErrorWithObject(e, errorLogObjects);
+                    _logger.LogWithObject(_serviceOptions.LogLevelOverride(LogLevel.Error),
+                                          e,
+                                          logObjects: errorLogObjects);
                     return new OperationResult<T>(ActionStatus.InternalServerError);
                 }
             }
@@ -286,7 +290,9 @@ namespace ATI.Services.Consul
                 }
                 catch (Exception e)
                 {
-                    _logger.ErrorWithObject(e, new { body, additionalLabels });
+                    _logger.LogWithObject(_serviceOptions.LogLevelOverride(LogLevel.Error),
+                                          e,
+                                          logObjects: new { body, additionalLabels });
                     return new OperationResult<T>(ActionStatus.InternalServerError);
                 }
             }

--- a/ATI.Services.Consul/ConsulMetricsHttpClientWrapper.cs
+++ b/ATI.Services.Consul/ConsulMetricsHttpClientWrapper.cs
@@ -40,6 +40,7 @@ namespace ATI.Services.Consul
             var config = new TracedHttpClientConfig(serviceOptions.ConsulName, serviceOptions.TimeOut, 
                 serviceOptions.SerializerType, serviceOptions.AddCultureToRequest, newtonsoftSettings, systemTextJsonOptions)
             {
+                LogTimeoutsAsWarn = serviceOptions.LogTimeoutsAsWarn,
                 HeadersToProxy = serviceOptions.HeadersToProxy
             };
 


### PR DESCRIPTION
Support for new parameter `LogTimeoutsAsWarn` in ConsulMetricsHttpClientWrapper