### PR TITLE
Consul cache background update

### DIFF
--- a/ATI.Services.Consul/ConsulAdapter.cs
+++ b/ATI.Services.Consul/ConsulAdapter.cs
@@ -13,7 +13,7 @@ internal class ConsulAdapter: IDisposable
 {
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
     private readonly ConsulClient _consulClient = new();
-    private readonly MetricsFactory _metricsFactory = MetricsFactory.CreateExternalHttpMetricsFactory();
+    private readonly MetricsFactory _metricsFactory = MetricsFactory.CreateHttpClientMetricsFactory(nameof(ConsulAdapter), "consul");
 
     /// <summary>
     /// Возвращает список живых сервисов

--- a/ATI.Services.Consul/ConsulAdapter.cs
+++ b/ATI.Services.Consul/ConsulAdapter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Consul;
+using NLog;
+
+namespace ATI.Services.Consul;
+
+internal class ConsulAdapter: IDisposable
+{
+    private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
+    private ConsulClient _consulClient;
+
+    /// <summary>
+    /// Возвращает список живых сервисов
+    /// </summary>
+    /// <returns></returns>
+    public async Task<List<ServiceEntry>> GetPassingServiceInstancesAsync(string serviceName, string environment, bool passingOnly = true, ulong index = 0, TimeSpan? waitTime = null)
+    {
+        try
+        {
+            _consulClient = new ConsulClient();
+            var fromConsul = await _consulClient.Health.Service(serviceName, environment, passingOnly, new QueryOptions { WaitIndex = index, WaitTime = waitTime});
+            if (fromConsul.StatusCode == HttpStatusCode.OK)
+            {
+                return fromConsul.Response?.ToList();
+            }
+
+            _logger.Error($"По запросу в консул {serviceName}:{environment}, вернулся ответ со статусом: {fromConsul.StatusCode}");
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e);
+        }
+        
+        return new List<ServiceEntry>();
+    }
+
+    public void Dispose()
+    {
+        _consulClient?.Dispose();
+    }
+}

--- a/ATI.Services.Consul/ConsulAdapter.cs
+++ b/ATI.Services.Consul/ConsulAdapter.cs
@@ -17,16 +17,17 @@ internal class ConsulAdapter: IDisposable
     private readonly MetricsFactory _metricsFactory = MetricsFactory.CreateHttpClientMetricsFactory(nameof(ConsulAdapter), "consul");
 
     /// <summary>
-    /// Возвращает список живых сервисов
+    /// Возвращает список живых инстансов сервиса
     /// </summary>
     /// <returns></returns>
-    public async Task<OperationResult<List<ServiceEntry>>> GetPassingServiceInstancesAsync(string serviceName,
-                                                                          string environment,
-                                                                          bool passingOnly = true)
+    public async Task<OperationResult<List<ServiceEntry>>> GetPassingServiceInstancesAsync(
+        string serviceName,
+        string environment,
+        bool passingOnly = true)
     {
         try
         {
-            using (_metricsFactory.CreateMetricsTimer(nameof(GetPassingServiceInstancesAsync)))
+            using (_metricsFactory.CreateMetricsTimer("/health/service/:service"))
             {
                 var fromConsul = await _consulClient.Health.Service(serviceName, environment, passingOnly);
                 if (fromConsul.StatusCode == HttpStatusCode.OK)

--- a/ATI.Services.Consul/ConsulAdapter.cs
+++ b/ATI.Services.Consul/ConsulAdapter.cs
@@ -17,12 +17,12 @@ internal class ConsulAdapter: IDisposable
     /// Возвращает список живых сервисов
     /// </summary>
     /// <returns></returns>
-    public async Task<List<ServiceEntry>> GetPassingServiceInstancesAsync(string serviceName, string environment, bool passingOnly = true, ulong index = 0, TimeSpan? waitTime = null)
+    public async Task<List<ServiceEntry>> GetPassingServiceInstancesAsync(string serviceName, string environment, bool passingOnly = true)
     {
         try
         {
             _consulClient = new ConsulClient();
-            var fromConsul = await _consulClient.Health.Service(serviceName, environment, passingOnly, new QueryOptions { WaitIndex = index, WaitTime = waitTime});
+            var fromConsul = await _consulClient.Health.Service(serviceName, environment, passingOnly);
             if (fromConsul.StatusCode == HttpStatusCode.OK)
             {
                 return fromConsul.Response?.ToList();

--- a/ATI.Services.Consul/ConsulMetricsHttpClientWrapper.cs
+++ b/ATI.Services.Consul/ConsulMetricsHttpClientWrapper.cs
@@ -18,7 +18,7 @@ namespace ATI.Services.Consul
     /// Обертка, включающая в себя ConsulServiceAddress, TracingHttpClientWrapper и MetricsTracingFactory
     /// </summary>
     [PublicAPI]
-    public class ConsulMetricsHttpClientWrapper
+    public class ConsulMetricsHttpClientWrapper : IDisposable
     {
         private readonly BaseServiceOptions _serviceOptions;
         private readonly MetricsHttpClientWrapper _clientWrapper;
@@ -296,6 +296,11 @@ namespace ATI.Services.Consul
                     return new OperationResult<T>(ActionStatus.InternalServerError);
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            _serviceAddress?.Dispose();
         }
     }
 }

--- a/ATI.Services.Consul/ConsulServiceAddress.cs
+++ b/ATI.Services.Consul/ConsulServiceAddress.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using ATI.Services.Common.Extensions;
 using Consul;
@@ -9,37 +8,45 @@ using NLog;
 
 namespace ATI.Services.Consul
 {
-    public class ConsulServiceAddress: IDisposable
+    public class ConsulServiceAddress : IDisposable
     {
         private readonly string _environment;
         private readonly string _serviceName;
         private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
-        private readonly Timer _updateCacheTimer;
-        private ConsulServiceAddressCache CachedServices { get; }
+        private readonly Func<Task<List<ServiceEntry>>> _getServices;
+        private readonly ConsulServiceAddressCache _serviceAddressCache;
+        private readonly ConsulAdapter _consulAdapter;
 
-        public ConsulServiceAddress(string serviceName, string environment, TimeSpan? timeToReload = null, bool useCaching = true)
+        public ConsulServiceAddress(string serviceName,
+                                    string environment,
+                                    TimeSpan? timeToReload = null,
+                                    bool useCaching = true)
         {
             timeToReload ??= TimeSpan.FromSeconds(5);
             _environment = environment;
             _serviceName = serviceName;
 
-            CachedServices = new ConsulServiceAddressCache(useCaching, _serviceName, _environment);
-            
-            _updateCacheTimer = new Timer(_ => CachedServices.ReloadCache(), null, timeToReload.Value,
-                timeToReload.Value);
+            if (useCaching)
+            {
+                _serviceAddressCache = new ConsulServiceAddressCache(_serviceName, _environment, timeToReload.Value);
+                _getServices = () => Task.FromResult(_serviceAddressCache.GetCachedObjectsAsync());
+            }
+            else
+            {
+                _consulAdapter = new ConsulAdapter();
+                _getServices = async () =>
+                    await _consulAdapter.GetPassingServiceInstancesAsync(serviceName, environment);
+            }
         }
 
-        public async Task<List<ServiceEntry>> GetAllAsync()
-        {
-            return await CachedServices.GetCachedObjectsAsync();
-        }
+        public Task<List<ServiceEntry>> GetAllAsync() => _getServices();
 
         public async Task<string> ToHttpAsync()
         {
-            var serviceInfo = (await CachedServices.GetCachedObjectsAsync()).RandomItem();
+            var serviceInfo = (await _getServices()).RandomItem();
             var address = string.IsNullOrWhiteSpace(serviceInfo?.Service?.Address)
-                ? serviceInfo?.Node.Address
-                : serviceInfo.Service.Address;
+                              ? serviceInfo?.Node.Address
+                              : serviceInfo.Service.Address;
 
             if (string.IsNullOrWhiteSpace(address) || serviceInfo.Service == null)
             {
@@ -52,10 +59,10 @@ namespace ATI.Services.Consul
 
         public async Task<(string, int)> GetAddressAndPortAsync()
         {
-            var serviceInfo = (await CachedServices.GetCachedObjectsAsync()).RandomItem();
+            var serviceInfo = (await _getServices()).RandomItem();
             var address = string.IsNullOrWhiteSpace(serviceInfo?.Service?.Address)
-                ? serviceInfo?.Node.Address
-                : serviceInfo.Service.Address;
+                              ? serviceInfo?.Node.Address
+                              : serviceInfo.Service.Address;
 
             if (string.IsNullOrWhiteSpace(address) || serviceInfo.Service == null)
             {
@@ -67,19 +74,19 @@ namespace ATI.Services.Consul
         }
 
         #region Obsolete
-        
+
         [Obsolete("Method GetAll is deprecated, pls use GetAllAsync instead")]
         public List<ServiceEntry> GetAll()
         {
             return GetAllAsync().GetAwaiter().GetResult();
         }
-        
+
         [Obsolete("Method ToHttp is deprecated, pls use ToHttpAsync instead")]
         public string ToHttp()
         {
             return ToHttpAsync().GetAwaiter().GetResult();
         }
-        
+
         [Obsolete("Method GetAddressAndPort is deprecated, pls use GetAddressAndPortAsync instead")]
         public (string, int) GetAddressAndPort()
         {
@@ -87,10 +94,11 @@ namespace ATI.Services.Consul
         }
 
         #endregion
-        
+
         public void Dispose()
         {
-            _updateCacheTimer.Dispose();
+            _serviceAddressCache?.Dispose();
+            _consulAdapter?.Dispose();
         }
     }
 }

--- a/ATI.Services.Consul/ConsulServiceAddress.cs
+++ b/ATI.Services.Consul/ConsulServiceAddress.cs
@@ -20,7 +20,8 @@ namespace ATI.Services.Consul
         public ConsulServiceAddress(string serviceName,
                                     string environment,
                                     TimeSpan? timeToReload = null,
-                                    bool useCaching = true)
+                                    bool useCaching = true,
+                                    bool passingOnly = true)
         {
             timeToReload ??= TimeSpan.FromSeconds(5);
             _environment = environment;
@@ -28,14 +29,14 @@ namespace ATI.Services.Consul
 
             if (useCaching)
             {
-                _serviceAddressCache = new ConsulServiceAddressCache(_serviceName, _environment, timeToReload.Value);
+                _serviceAddressCache = new ConsulServiceAddressCache(_serviceName, _environment, timeToReload.Value, passingOnly);
                 _getServices = () => Task.FromResult(_serviceAddressCache.GetCachedObjectsAsync());
             }
             else
             {
                 _consulAdapter = new ConsulAdapter();
                 _getServices = async () =>
-                    await _consulAdapter.GetPassingServiceInstancesAsync(serviceName, environment);
+                    await _consulAdapter.GetPassingServiceInstancesAsync(serviceName, environment, passingOnly);
             }
         }
 

--- a/ATI.Services.Consul/ConsulServiceAddressCache.cs
+++ b/ATI.Services.Consul/ConsulServiceAddressCache.cs
@@ -30,7 +30,10 @@ internal class ConsulServiceAddressCache: IDisposable
         _consulAdapter = new ConsulAdapter();
         _updateCacheTask = _consulAdapter.GetPassingServiceInstancesAsync(_serviceName, _environment, passingOnly);
         _cachedServices = _updateCacheTask.GetAwaiter().GetResult();
+        
+        #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         _updateCacheTimer = new Timer(_ => ReloadCache(), null, ttl, ttl);
+        #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
     }
         
     /// <summary>
@@ -42,12 +45,12 @@ internal class ConsulServiceAddressCache: IDisposable
     /// <summary>
     /// Запускает таску на обновление кеша
     /// </summary>
-    private void ReloadCache()
+    private async Task ReloadCache()
     {
         if(_updateCacheTask == null || _updateCacheTask.IsCompleted)
             _updateCacheTask = _consulAdapter.GetPassingServiceInstancesAsync(_serviceName, _environment, _passingOnly);
         
-        _cachedServices = _updateCacheTask.GetAwaiter().GetResult();
+        _cachedServices = await _updateCacheTask;
     }
 
     public void Dispose()

--- a/ATI.Services.Consul/ConsulServiceAddressCache.cs
+++ b/ATI.Services.Consul/ConsulServiceAddressCache.cs
@@ -60,5 +60,6 @@ internal class ConsulServiceAddressCache: IDisposable
     public void Dispose()
     {
         _updateCacheTimer.Dispose();
+        _consulAdapter.Dispose();
     }
 }

--- a/ATI.Services.Consul/ConsulServiceAddressCache.cs
+++ b/ATI.Services.Consul/ConsulServiceAddressCache.cs
@@ -23,8 +23,9 @@ internal class ConsulServiceAddressCache: IDisposable
         _serviceName = serviceName;
         _environment = environment;
         _consulAdapter = new ConsulAdapter();
+        _updateCacheTask = _consulAdapter.GetPassingServiceInstancesAsync(_serviceName, _environment);
+        _cachedServices = _updateCacheTask.GetAwaiter().GetResult();
         _updateCacheTimer = new Timer(_ => ReloadCache(), null, ttl, ttl);
-        _cachedServices = _consulAdapter.GetPassingServiceInstancesAsync(serviceName, environment).GetAwaiter().GetResult();
     }
         
     /// <summary>
@@ -38,7 +39,7 @@ internal class ConsulServiceAddressCache: IDisposable
     /// </summary>
     private void ReloadCache()
     {
-        if(_updateCacheTask.IsCompleted)
+        if(_updateCacheTask == null || _updateCacheTask.IsCompleted)
             _updateCacheTask = _consulAdapter.GetPassingServiceInstancesAsync(_serviceName, _environment);
         
         _cachedServices = _updateCacheTask.GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary
Fixes long wait time for resolving address using `ConsulServiceAddress` in some situations.
Added metrics for consul request.

## Details 
In situations when Consul response time increases: 
**Previously** `ConsulServiceAddress` awaited consul for response if cache update is in process. It produced situation when all request to other service were blocked until Consul response returned. Situation repeats each cache update(default 5 sec).
Cache clears itself in case of error response from consul, next requests will be resolved with error "Не удалось взять настройки из консула для service:environment", until success cache update occures.

**Now** `ConsulServiceAddress` always resolves service address from cache. **Warning:** Cache will not be changed in case consul returns error response, next requests use potentially outdated cache.